### PR TITLE
Added a PressType to disable automatic time popups

### DIFF
--- a/lib/time_picker_spinner_enum.dart
+++ b/lib/time_picker_spinner_enum.dart
@@ -7,4 +7,7 @@ enum PressType {
 
   /// User single-presses on the time widget
   singlePress,
+
+  /// Disables automatic time popup on user presses.
+  disablePress,
 }


### PR DESCRIPTION
Hi,

I return a Button inside the `timeWidgetBuilder` in my current project. That button sometimes needs to be disabled. But the time popup would still automatically popup on presses due to the current `InkWell` containers inside the `TimePickerSpinnerPopUp`.

Therefore, I added a `disablePress` enum to be able to disable these automatic popups. `disablePress` will disable the popups since `InkWell` `onTap` and `onLongPress` explicitly only check against `singlePress` and `longPress`.