### PR TITLE
Updated the intl dependency from version 19.0 to 20.2 for Flutter 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: time_picker_spinner_pop_up
 description: A package show popup anchor for pick date time by using spinner cupertino style
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/tuannvm2109/time_picker_spinner_pop_up
 
 environment:
-  sdk: ">=2.17.6 <3.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.9.2 <4.0.0"
+  flutter: ^3.35.3
 
 dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.19.0
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Because time_picker_spinner_pop_up 2.0.0 depends on intl ^0.19.0 and no versions of time_picker_spinner_pop_up match >2.0.0 <3.0.0, time_picker_spinner_pop_up ^2.0.0 requires intl ^0.19.0.